### PR TITLE
Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ connect-db:
 
 run:
 	@mvn clean
-	@mvn spring-boot:run
+	@mvn spring-boot:run  -Dspring.config.location=file:tmp/application.yml
 
 build:
 	@mvn verify

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+SHELL:=/bin/bash
+
+MYSQL_VERSION=8
+MYSQL_PORT=3306
+MYSQL_DATA=/tmp/tgnitifier-db
+
+.PHONY: help start-db clean-db connect-db
+all: help
+help: Makefile
+	@echo
+	@echo " Choose a command run in "$(PROJECTNAME)":"
+	@echo
+	@sed -n 's/^##//p' $< | column -t -s ':' |  sed -e 's/^/ /'
+	@echo
+
+start-db:
+	@docker network create tg-mysql || true
+	@docker run -d --network tg-mysql --name tg-mysql -v ${MYSQL_DATA}:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=password -e MYSQL_DATABASE=tgnotifier -p ${MYSQL_PORT}:3306 mysql:${MYSQL_VERSION} || true
+	@echo "DB started, connect with make connect-db"
+
+stop-db:
+	@docker stop tg-mysql || true
+
+clean-db: stop-db
+	@docker rm tg-mysql || true
+	@docker network rm tg-mysql || true
+	@sudo rm -Rf ${MYSQL_DATA} || true
+	@echo "DB cleaned"
+
+logs-db: start-db
+	@docker logs -f tg-mysql
+
+connect-db:
+	@echo "Default password is: password"
+	@docker run -it --network tg-mysql --rm mysql:${MYSQL_VERSION} mysql -htg-mysql -uroot -p
+
+run:
+	@mvn clean
+	@mvn spring-boot:run
+
+build:
+	@mvn verify


### PR DESCRIPTION
Add makefile to make development setup easier.

Developers can create tmp/application.yaml where the DB settings look like:
```
spring:
  jpa:
    #    open-in-view: false
    database: mysql
    show-sql: false
    hibernate:
      ddl-auto: create
    properties.hibernate:
      dialect: org.hibernate.dialect.MySQL8Dialect
      jdbc.lob.non_contextual_creation: true

  datasource:
    platform: mysql
    url: jdbc:mysql://127.0.0.1:3306/tgnotifier
    username: root
    password: password
    driver-class-name: com.mysql.cj.jdbc.Driver
    hikari:
      maximum-pool-size: 3


tgnotifier:
  telegramToken: XXXXXX
  wsUrl: ethparser_url
  showDescriptions: false

logging:
  level:
    pro:
      belbix:
        ethparser:
          web3:
            uniswap: TRACE
    org:
      springframework:
        web:
          filter:
            CommonsRequestLoggingFilter: DEBUG
```

The bot can be stated in two commands:
`make start-db` (uses docker)
`make run`

Other commands exists to check db status, clean it up....