### PR TITLE
Task 2056-b bot usability after restart

### DIFF
--- a/src/main/java/pro/belbix/tgnotifier/db/DbService.java
+++ b/src/main/java/pro/belbix/tgnotifier/db/DbService.java
@@ -55,7 +55,7 @@ public class DbService {
         String lastCommand = userEntity.getLastCommand();
 
         if (lastCommand == null) {
-            return new UserResponse("Please, use command before setup value", null, false);
+            return new UserResponse("Please, use command before setup value", null, true);
         }
 
         try {

--- a/src/main/java/pro/belbix/tgnotifier/tg/Commands.java
+++ b/src/main/java/pro/belbix/tgnotifier/tg/Commands.java
@@ -9,13 +9,16 @@ import pro.belbix.tgnotifier.db.entity.UserEntity;
 
 public class Commands {
 
-    public static final String WELCOME_MESSAGE = "Welcome! By default you are not subscribed to any events. "
-        + "Select an option from the menu below.";
+    public static final String WELCOME_MESSAGE =
+        "Welcome! By default you are not subscribed to any events. "
+            + "Select an option from the menu below.";
     public final static String PERCENT_VALUE_CALLBACK = "Now send percent value";
     public final static String VALUE_CALLBACK = "Now send correct number value";
     public final static String TOKEN_CALLBACK = "Now send correct token name";
     public final static String ADDRESS_CALLBACK = "Now send correct hash for address";
     public final static String CONFIRM_CALLBACK = "Are you sure? Type `yes` to confirm";
+
+    public final static String START = "/start";
 
     public final static String INFO = "⚙ Show Settings";
     public final static String INFO_DESC = "Show your settings";
@@ -29,8 +32,9 @@ public class Commands {
     public final static String FARM_CHANGE_DESC = "FARM price change notification, in %";
 
     public final static String FARM_MIN = "FARM Txs in USD";
-    public final static String FARM_MIN_DESC = "You will receive notifications about Uniswap FARM/USDC transactions "
-        + "including more FARM than this value";
+    public final static String FARM_MIN_DESC =
+        "You will receive notifications about Uniswap FARM/USDC transactions "
+            + "including more FARM than this value";
 
     public final static String TVL_CHANGE = "TVL Change in %";
     public final static String TVL_CHANGE_DESC = "All TVL change notification, in %";
@@ -43,8 +47,9 @@ public class Commands {
     public final static String PS_APR_CHANGE_DESC = "Profit Share APR change notification, in %";
 
     public final static String HARD_WORK_MIN = "HardWork Change in USD";
-    public final static String HARD_WORK_MIN_DESC = "You will receive notifications about doHardWork calls "
-        + "earned more USD than this value";
+    public final static String HARD_WORK_MIN_DESC =
+        "You will receive notifications about doHardWork calls "
+            + "earned more USD than this value";
 
     public final static String SUBSCRIBE_ON_ADDRESS = "Address Events";
     public final static String SUBSCRIBE_ON_DESC = "Subscribe to all events related to this address";
@@ -56,8 +61,9 @@ public class Commands {
     public final static String STRATEGY_ANNOUNCE_DESC = "Receive notifications about Vault strategy announces";
 
     public final static String TOKEN_MINT = "Token Mint";
-    public final static String TOKEN_MINT_DESC = "Receive notifications about FARM token (new emissions) "
-        + "minted more than set value";
+    public final static String TOKEN_MINT_DESC =
+        "Receive notifications about FARM token (new emissions) "
+            + "minted more than set value";
 
     public final static String TOKEN_PRICE_SUBSCRIBE = "🪙   Token Price Subscribe";
     public final static String TOKEN_PRICE_SUBSCRIBE_DESC = "Receive notifications about a token price change";
@@ -68,9 +74,12 @@ public class Commands {
     public final static String HELP_TEXT = "Select an entry from the menu below.";
     public final static String UNKNOWN_COMMAND = "Incorrect or unknown command.";
 
-    public final static String[] COMMANDS = new String[]{INFO, FARM_NOTIFICATIONS, TVL_NOTIFICATIONS,
-        STRATEGY_NOTIFICATIONS, PS_NOTIFICATIONS, FARM_CHANGE, FARM_MIN, TVL_CHANGE, TVL_MIN, PS_APR_CHANGE,
-        HARD_WORK_MIN, SUBSCRIBE_ON_ADDRESS, STRATEGY_CHANGE, STRATEGY_ANNOUNCE, TOKEN_MINT, TOKEN_PRICE_SUBSCRIBE,
+    public final static String[] COMMANDS = new String[]{START, FARM_NOTIFICATIONS,
+        TVL_NOTIFICATIONS,
+        STRATEGY_NOTIFICATIONS, PS_NOTIFICATIONS, FARM_CHANGE, FARM_MIN, TVL_CHANGE, TVL_MIN,
+        PS_APR_CHANGE,
+        HARD_WORK_MIN, SUBSCRIBE_ON_ADDRESS, STRATEGY_CHANGE, STRATEGY_ANNOUNCE, TOKEN_MINT,
+        TOKEN_PRICE_SUBSCRIBE,
         TOKEN_PRICE_SUBSCRIBE_CHANGE};
 
     public static UserResponse responseForCommand(String command) {
@@ -78,6 +87,8 @@ public class Commands {
             return new UserResponse(UNKNOWN_COMMAND, null);
         }
         switch (command) {
+            case START:
+                return new UserResponse(WELCOME_MESSAGE, null, true);
             case FARM_NOTIFICATIONS:
                 InlineButton[] buttonsFarmNotifications = {
                     new InlineButton(FARM_CHANGE, FARM_CHANGE),
@@ -107,7 +118,8 @@ public class Commands {
                     new InlineButton("10", "10"),
                     new InlineButton("Cancel", "0")
                 };
-                return new UserResponse(FARM_CHANGE_DESC + "\n" + PERCENT_VALUE_CALLBACK, buttonsFarmChange);
+                return new UserResponse(FARM_CHANGE_DESC + "\n" + PERCENT_VALUE_CALLBACK,
+                    buttonsFarmChange);
             case FARM_MIN:
                 InlineButton[] buttonsFarmMin = {
                     new InlineButton("1000", "1000"),
@@ -119,7 +131,8 @@ public class Commands {
                     new InlineButton("10", "10"),
                     new InlineButton("Cancel", "0")
                 };
-                return new UserResponse(TVL_CHANGE_DESC + "\n" + PERCENT_VALUE_CALLBACK, buttonsTVLChange);
+                return new UserResponse(TVL_CHANGE_DESC + "\n" + PERCENT_VALUE_CALLBACK,
+                    buttonsTVLChange);
             case TVL_MIN:
                 InlineButton[] buttonsTVLMin = {
                     new InlineButton("10000", "10000"),
@@ -131,7 +144,8 @@ public class Commands {
                     new InlineButton("10", "10"),
                     new InlineButton("Cancel", "0")
                 };
-                return new UserResponse(PS_APR_CHANGE_DESC + "\n" + PERCENT_VALUE_CALLBACK, buttonsAPRChange);
+                return new UserResponse(PS_APR_CHANGE_DESC + "\n" + PERCENT_VALUE_CALLBACK,
+                    buttonsAPRChange);
             case HARD_WORK_MIN:
                 InlineButton[] buttonsHrdwMin = {
                     new InlineButton("10000", "10000"),
@@ -139,21 +153,24 @@ public class Commands {
                 };
                 return new UserResponse(HARD_WORK_MIN_DESC + "\n" + VALUE_CALLBACK, buttonsHrdwMin);
             case SUBSCRIBE_ON_ADDRESS:
-                return new UserResponse(SUBSCRIBE_ON_ADDRESS + "\n" + ADDRESS_CALLBACK, null, false);
+                return new UserResponse(SUBSCRIBE_ON_ADDRESS + "\n" + ADDRESS_CALLBACK, null,
+                    false);
             case STRATEGY_CHANGE:
                 InlineButton[] buttonsStgChange = {
                     new InlineButton("Yes", "Yes"),
                     new InlineButton("No", "No"),
                     new InlineButton("Cancel", "0")
                 };
-                return new UserResponse(STRATEGY_CHANGE_DESC + "\n" + CONFIRM_CALLBACK, buttonsStgChange);
+                return new UserResponse(STRATEGY_CHANGE_DESC + "\n" + CONFIRM_CALLBACK,
+                    buttonsStgChange);
             case STRATEGY_ANNOUNCE:
                 InlineButton[] buttonsStgAnnounce = {
                     new InlineButton("Yes", "Yes"),
                     new InlineButton("No", "No"),
                     new InlineButton("Cancel", "0")
                 };
-                return new UserResponse(STRATEGY_ANNOUNCE_DESC + "\n" + CONFIRM_CALLBACK, buttonsStgAnnounce);
+                return new UserResponse(STRATEGY_ANNOUNCE_DESC + "\n" + CONFIRM_CALLBACK,
+                    buttonsStgAnnounce);
             case TOKEN_MINT:
                 InlineButton[] buttonsTokenMint = {
                     new InlineButton("1000", "1000"),
@@ -167,55 +184,69 @@ public class Commands {
                     new InlineButton("10", "10"),
                     new InlineButton("Cancel", "0")
                 };
-                return new UserResponse(TOKEN_PRICE_SUBSCRIBE_CHANGE_DESC + "\n" + PERCENT_VALUE_CALLBACK,
+                return new UserResponse(
+                    TOKEN_PRICE_SUBSCRIBE_CHANGE_DESC + "\n" + PERCENT_VALUE_CALLBACK,
                     buttonsTokenPriceSubscribeChange);
         }
         return new UserResponse(UNKNOWN_COMMAND, null);
     }
 
     public static String nextCommand(@NotNull String command) {
-        switch (command) {
-            case TOKEN_PRICE_SUBSCRIBE:
-                return TOKEN_PRICE_SUBSCRIBE_CHANGE;
+        if (TOKEN_PRICE_SUBSCRIBE.equals(command)) {
+            return TOKEN_PRICE_SUBSCRIBE_CHANGE;
         }
 
         return null;
     }
 
-    public static boolean fillFieldForCommand(@NotNull String command, @NotNull UserEntity userEntity, String text) {
-        if (FARM_CHANGE.equals(command)) {
-            userEntity.setFarmChange(textToDouble(text));
-        } else if (FARM_MIN.equals(command)) {
-            userEntity.setMinFarmAmount(textToDouble(text));
-        } else if (TVL_CHANGE.equals(command)) {
-            userEntity.setTvlChange(textToDouble(text));
-        } else if (TVL_MIN.equals(command)) {
-            userEntity.setMinTvlAmount(textToDouble(text));
-        } else if (PS_APR_CHANGE.equals(command)) {
-            userEntity.setHardWorkChange(textToDouble(text));
-        } else if (HARD_WORK_MIN.equals(command)) {
-            userEntity.setMinHardWorkAmount(textToDouble(text));
-        } else if (SUBSCRIBE_ON_ADDRESS.equals(command)) {
-            String existAddresses = userEntity.getSubscribedAddress();
-            existAddresses = existAddresses == null ? "" : existAddresses + ",";
-            String hash = textToHash(text);
-            if (existAddresses.contains(hash)) {
-                userEntity.setSubscribedAddress(existAddresses.replace(hash + ",", ""));
-            } else {
-                userEntity.setSubscribedAddress(existAddresses + hash);
-            }
-        } else if (STRATEGY_CHANGE.equals(command)) {
-            userEntity.setStrategyChange(checkConfirmation(text));
-        } else if (STRATEGY_ANNOUNCE.equals(command)) {
-            userEntity.setStrategyAnnounce(checkConfirmation(text));
-        } else if (TOKEN_MINT.equals(command)) {
-            userEntity.setTokenMint(textToDouble(text));
-        } else if (TOKEN_PRICE_SUBSCRIBE.equals(command)) {
-            userEntity.setSelectedToken(text);
-        } else if (TOKEN_PRICE_SUBSCRIBE_CHANGE.equals(command)) {
-            insertOrUpdateToken(userEntity, userEntity.getSelectedToken(), textToDouble(text));
-        } else {
-            return false;
+    public static boolean fillFieldForCommand(@NotNull String command,
+                                              @NotNull UserEntity userEntity, String text) {
+        switch (command) {
+            case FARM_CHANGE:
+                userEntity.setFarmChange(textToDouble(text));
+                break;
+            case FARM_MIN:
+                userEntity.setMinFarmAmount(textToDouble(text));
+                break;
+            case TVL_CHANGE:
+                userEntity.setTvlChange(textToDouble(text));
+                break;
+            case TVL_MIN:
+                userEntity.setMinTvlAmount(textToDouble(text));
+                break;
+            case PS_APR_CHANGE:
+                userEntity.setHardWorkChange(textToDouble(text));
+                break;
+            case HARD_WORK_MIN:
+                userEntity.setMinHardWorkAmount(textToDouble(text));
+                break;
+            case SUBSCRIBE_ON_ADDRESS:
+                String existAddresses = userEntity.getSubscribedAddress();
+                existAddresses = existAddresses == null ? "" : existAddresses + ",";
+                String hash = textToHash(text);
+                if (existAddresses.contains(hash)) {
+                    userEntity.setSubscribedAddress(existAddresses.replace(hash + ",", ""));
+                } else {
+                    userEntity.setSubscribedAddress(existAddresses + hash);
+                }
+                break;
+            case STRATEGY_CHANGE:
+                userEntity.setStrategyChange(checkConfirmation(text));
+                break;
+            case STRATEGY_ANNOUNCE:
+                userEntity.setStrategyAnnounce(checkConfirmation(text));
+                break;
+            case TOKEN_MINT:
+                userEntity.setTokenMint(textToDouble(text));
+                break;
+            case TOKEN_PRICE_SUBSCRIBE:
+                userEntity.setSelectedToken(text);
+                break;
+            case TOKEN_PRICE_SUBSCRIBE_CHANGE:
+                insertOrUpdateToken(userEntity, userEntity.getSelectedToken(), textToDouble(text));
+                break;
+            default:
+                return false;
         }
         return true;
     }
@@ -251,10 +282,12 @@ public class Commands {
         } else if (deny.contains(text.toLowerCase())) {
             return false;
         }
-        throw new IllegalStateException("Incorrect value, type `yes` to confirm or type `no` to cancel");
+        throw new IllegalStateException(
+            "Incorrect value, type `yes` to confirm or type `no` to cancel");
     }
 
-    private static void insertOrUpdateToken(UserEntity userEntity, String tokenName, Double change) {
+    private static void insertOrUpdateToken(UserEntity userEntity, String tokenName,
+                                            Double change) {
         if (tokenName == null) {
             throw new IllegalStateException("Token not selected");
         }


### PR DESCRIPTION
## Links
[TASK](https://www.notion.so/harvestfinance/TG-In-some-cases-users-can-t-use-commands-dc31cf82441c4a62acc0b7bde58c3c9b)

## Description
Find bug, after deleting chatBot and re-entering. 
command /start doesnt work and botChatMenu not open after that i can't do anything with chat

## Resolve
add command "/start" to command list, add logic for it(open menu button and send hello message)
add "open menu button" if we have problem when lastCommand==null

## Screen
<img src="https://user-images.githubusercontent.com/28349362/110004251-484b7280-7d28-11eb-9931-84fd896872ec.png" width=200px/>
