### PR TITLE
(BUGFIX)1184-b Integrate JaCoCo and create GH coverage badge

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,36 @@
+# This workflow will build a Java project with Maven
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
+
+name: Pull Request script
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.0.17
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_USER: harvest
+          MYSQL_PASSWORD: harvest
+          MYSQL_DATABASE: harvest
+        ports:
+          - 3306:3306
+        options:
+          --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.11
+      - name: Build with Maven
+        run: mvn -Dtgnotifier.telegramToken="${{secrets.TELEGRAM_TOKEN}}" -Dtgnotifier.wsUrl="https://ethparser-api.herokuapp.com/stomp" -Dspring.datasource.url=jdbc:mysql://localhost:3306/harvest -Dspring.datasource.username=harvest -Dspring.datasource.password=harvest -B package -ff -T 1 --file pom.xml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,12 +1,10 @@
 # This workflow will build a Java project with Maven
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
-name: Java CI with Maven
+name: Push script
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master ]
 
 jobs:
@@ -35,7 +33,7 @@ jobs:
         with:
           java-version: 1.11
       - name: Build with Maven
-        run: mvn -Dtgnotifier.telegramToken="${{secrets.TELEGRAM_TOKEN}}" -Dtgnotifier.wsUrl="https://ethparser-staging.herokuapp.com/stomp" -Dspring.datasource.url=jdbc:mysql://localhost:3306/harvest -Dspring.datasource.username=harvest -Dspring.datasource.password=harvest -B package -ff -T 1 --file pom.xml
+        run: mvn -Dtgnotifier.telegramToken="${{secrets.TELEGRAM_TOKEN}}" -Dtgnotifier.wsUrl="https://ethparser-api.herokuapp.com/stomp" -Dspring.datasource.url=jdbc:mysql://localhost:3306/harvest -Dspring.datasource.username=harvest -Dspring.datasource.password=harvest -B package -ff -T 1 --file pom.xml
 
       - name: Generate JaCoCo Badge
         id: jacoco


### PR DESCRIPTION
## Links
[TASK](https://www.notion.so/harvestfinance/TG-Integrate-JaCoCo-and-create-GH-coverage-badge-a16b273564ba4bf0af3ebeb238133e77)

## Description
After pull request we catch exception
log:
Run if [[ `git status --porcelain` ]]; then
[detached HEAD 8a98cf9] Autogenerated JaCoCo coverage badge
 1 file changed, 1 insertion(+), 1 deletion(-)
fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD)
state now, use

    git push origin HEAD:<name-of-remote-branch>

Error: Process completed with exit code 128.

## Resolve
-separate gitActions script: start jacoco coverage script when we push, after code review
-change wsUrl in gitActions script(now we use prod link)



